### PR TITLE
Fix: Simplify Alembic migration chain to resolve table not found error

### DIFF
--- a/alembic/versions/6f2a20bcfaa1_add_description_to_infrastructure_type.py
+++ b/alembic/versions/6f2a20bcfaa1_add_description_to_infrastructure_type.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '6f2a20bcfaa1'
-down_revision = '63003f2a15fa'
+down_revision = 'b91a83b5f0ba'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
The Docker build was failing with a "relation units_of_measurement does not exist" error during Alembic migrations. This occurred when migration 98d98def6838 attempted to add a column to the units_of_measurement table.

This commit simplifies the migration chain by altering the `down_revision` of migration `6f2a20bcfaa1_add_description_to_infrastructure_type.py`. It now points to `b91a83b5f0ba_fresh_initial_schema_vx.py` (the initial schema setup) instead of `63003f2a15fa_initial_schema_vx.py`.

The bypassed migration `63003f2a15fa` had an unusual upgrade path that involved dropping numerous indexes that were created in the immediately preceding initial schema migration (`b91a83b5f0ba`). Removing this migration from the active chain makes the sequence more direct and less prone to errors in Alembic's graph resolution or state interpretation, which is suspected to be the cause of the table not being found.