### PR TITLE
Fix: Prevent transaction abort in populate_data_test.py

### DIFF
--- a/app/scripts/populate_data_test.py
+++ b/app/scripts/populate_data_test.py
@@ -71,7 +71,7 @@ async def _get_or_create(session: AsyncSession, model_cls: Type[ModelType], defa
             print(f"Successfully created and flushed {model_cls.__name__} (ID: {instance.id}).")
             created = True
         except IntegrityError as e:
-            await session.rollback()
+            # await session.rollback() # Line removed
             print(f"IntegrityError for {model_cls.__name__} with params {params}. Attempting to fetch conflicting record.")
 
             fetched_instance = None


### PR DESCRIPTION
Removed an explicit `session.rollback()` from the `IntegrityError` handler within the `_get_or_create` function. This was causing the entire session's transaction to be rolled back prematurely if an attempt to create an already existing entity failed with an IntegrityError.

With this change, if an IntegrityError occurs during a flush operation (e.g., due to a unique constraint violation), the function will now attempt to fetch the existing entity without aborting the broader transaction. This resolves the `asyncpg.exceptions.InFailedSQLTransactionError` that occurred when subsequent operations were attempted on the aborted transaction. The main `populate_database` function's error handling will still ensure a full rollback if any unrecoverable errors occur.