### PR TITLE
Fix: Correct keyword argument for capacity in Infrastructure model

### DIFF
--- a/app/scripts/populate_data_test.py
+++ b/app/scripts/populate_data_test.py
@@ -528,7 +528,7 @@ async def populate_main_data(session: AsyncSession, lookups: Dict[str, List[Any]
                 "infrastructure_type_id": dam_type_specific.id,
                 "reporting_unit_id": ru_blue_river_basin.id,
                 "operational_status_id": op_status_specific.id,
-                "capacity_value": Decimal("120.5"),
+                "capacity": Decimal("120.5"),
                 "capacity_unit_id": uom_mcm.id,
                 "construction_year": 2005
             }


### PR DESCRIPTION
The `populate_data_test.py` script was attempting to use `capacity_value` as a keyword argument when creating an `Infrastructure` object. The correct attribute name in the `Infrastructure` model is `capacity`.

This commit updates the script to use the correct keyword argument, resolving the TypeError that occurred during script execution.